### PR TITLE
Fix minify property in config example

### DIFF
--- a/docs/guide/front-end/dynamic-imports/index.md
+++ b/docs/guide/front-end/dynamic-imports/index.md
@@ -154,9 +154,9 @@ export default defineConfig(({ command, mode }) => ({
       publicPath: '/etc.clientlibs/<project>/clientlibs/clientlib-site',
       resourcesPath: 'resources/js',
 
+      minify: needsCaching, // [!code focus]
       caching: { // [!code focus]
         enabled: command === 'build' && mode === 'production' && needsCaching, // [!code focus]
-        minification: needsCaching, // [!code focus]
       }, // [!code focus]
     }),
   ],


### PR DESCRIPTION
Property is named `minify` and should be part of `BaseImportRewriterOptions`

https://github.com/aem-vite/import-rewriter/blob/main/src/types.ts#L57